### PR TITLE
Add group search feature

### DIFF
--- a/lib/screens/find_group_screen.dart
+++ b/lib/screens/find_group_screen.dart
@@ -1,0 +1,637 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../models/user_profile.dart';
+import '../models/friend_group.dart';
+import '../movie.dart';
+import '../services/group_service.dart';
+import '../utils/themed_notifications.dart';
+import '../utils/debug_loader.dart';
+import 'group_detail_screen.dart';
+
+class FindGroupScreen extends StatefulWidget {
+  final UserProfile currentUser;
+  final List<Movie> allMovies;
+
+  const FindGroupScreen({
+    super.key,
+    required this.currentUser,
+    required this.allMovies,
+  });
+
+  @override
+  State<FindGroupScreen> createState() => _FindGroupScreenState();
+}
+
+class _FindGroupScreenState extends State<FindGroupScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  final List<FriendGroup> _searchResults = [];
+  bool _isSearching = false;
+  Timer? _debounceTimer;
+  String _lastQuery = '';
+
+  final GroupService _groupService = GroupService();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _debounceTimer?.cancel();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String query) {
+    _debounceTimer?.cancel();
+
+    if (query.isEmpty) {
+      setState(() {
+        _searchResults.clear();
+        _isSearching = false;
+        _lastQuery = '';
+      });
+      return;
+    }
+
+    if (query == _lastQuery || query.length < 2) {
+      return;
+    }
+
+    if (!_isSearching) {
+      setState(() {
+        _isSearching = true;
+      });
+    }
+
+    _debounceTimer = Timer(const Duration(milliseconds: 800), () {
+      _searchGroups(query);
+    });
+  }
+
+  void _searchGroups(String query) async {
+    if (!mounted || query != _searchController.text || query == _lastQuery) {
+      return;
+    }
+
+    _lastQuery = query;
+
+    try {
+      DebugLogger.log('🔍 Searching public groups for: $query');
+
+      final results = await _groupService
+          .searchPublicGroups(query)
+          .timeout(const Duration(seconds: 5));
+
+      if (!mounted || query != _searchController.text) {
+        return;
+      }
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _searchResults
+              ..clear()
+              ..addAll(results);
+            _isSearching = false;
+          });
+        }
+      });
+
+      DebugLogger.log('✅ Group search completed: ${results.length} results');
+    } catch (e) {
+      DebugLogger.log('❌ Group search error: $e');
+
+      if (!mounted) return;
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() {
+            _isSearching = false;
+          });
+
+          ThemedNotifications.showError(context, 'Search failed: $e');
+        }
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1F1F1F),
+        elevation: 0,
+        title: Text(
+          'Find Groups',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 24.sp,
+            letterSpacing: 0.5,
+          ),
+        ),
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Color(0xFF121212),
+              Color(0xFF0A0A0A),
+            ],
+          ),
+        ),
+        child: Column(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    const Color(0xFF1F1F1F),
+                    const Color(0xFF1F1F1F).withOpacity(0.8),
+                  ],
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.3),
+                    blurRadius: 8.r,
+                    offset: Offset(0, 2.h),
+                  ),
+                ],
+              ),
+              child: Padding(
+                padding: EdgeInsets.all(20.w),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Find Groups',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 20.sp,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: 0.5,
+                      ),
+                    ),
+                    SizedBox(height: 8.h),
+                    Text(
+                      'Search public groups to join',
+                      style: TextStyle(
+                        color: Colors.white.withOpacity(0.7),
+                        fontSize: 14.sp,
+                      ),
+                    ),
+                    SizedBox(height: 20.h),
+                    Container(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(16.r),
+                        border: Border.all(
+                          color:
+                              const Color(0xFFE5A00D).withOpacity(0.2),
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withOpacity(0.2),
+                            blurRadius: 8.r,
+                            offset: Offset(0, 2.h),
+                          ),
+                        ],
+                      ),
+                      child: TextField(
+                        controller: _searchController,
+                        decoration: InputDecoration(
+                          hintText: 'Search for groups...',
+                          hintStyle: TextStyle(
+                            color: Colors.white.withOpacity(0.5),
+                            fontSize: 16.sp,
+                          ),
+                          prefixIcon: Icon(
+                            Icons.search,
+                            color: const Color(0xFFE5A00D),
+                            size: 24.sp,
+                          ),
+                          filled: true,
+                          fillColor: const Color(0xFF2A2A2A),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(16.r),
+                            borderSide: BorderSide.none,
+                          ),
+                          contentPadding: EdgeInsets.symmetric(
+                            vertical: 16.h,
+                            horizontal: 20.w,
+                          ),
+                        ),
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 16.sp,
+                        ),
+                        onChanged: _onSearchChanged,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Expanded(
+              child: _searchController.text.isEmpty
+                  ? _buildEmptySearchState()
+                  : _isSearching
+                      ? _buildLoadingState()
+                      : _searchResults.isEmpty
+                          ? _buildNoResultsState()
+                          : _buildSearchResults(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptySearchState() {
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(40.w),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              padding: EdgeInsets.all(32.w),
+              decoration: BoxDecoration(
+                gradient: const LinearGradient(
+                  colors: [
+                    Color(0xFF2A2A2A),
+                    Color(0xFF1F1F1F),
+                  ],
+                ),
+                borderRadius: BorderRadius.circular(24.r),
+                border: Border.all(
+                  color: const Color(0xFFE5A00D).withOpacity(0.2),
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.3),
+                    blurRadius: 20.r,
+                    offset: Offset(0, 8.h),
+                  ),
+                ],
+              ),
+              child: Icon(
+                Icons.group,
+                size: 72.sp,
+                color: const Color(0xFFE5A00D).withOpacity(0.8),
+              ),
+            ),
+            SizedBox(height: 32.h),
+            Text(
+              'Discover Movie Groups',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 28.sp,
+                fontWeight: FontWeight.bold,
+                letterSpacing: 0.5,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 16.h),
+            Text(
+              'Type a name above to search for public groups',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.7),
+                fontSize: 16.sp,
+                height: 1.5,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadingState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            padding: EdgeInsets.all(20.w),
+            decoration: BoxDecoration(
+              color: const Color(0xFF1F1F1F),
+              borderRadius: BorderRadius.circular(16.r),
+            ),
+            child: CircularProgressIndicator(
+              color: const Color(0xFFE5A00D),
+              strokeWidth: 3.w,
+            ),
+          ),
+          SizedBox(height: 16.h),
+          Text(
+            'Searching for groups...',
+            style: TextStyle(
+              color: Colors.white70,
+              fontSize: 16.sp,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoResultsState() {
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(40.w),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              padding: EdgeInsets.all(24.w),
+              decoration: BoxDecoration(
+                color: Colors.orange.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(20.r),
+                border: Border.all(
+                  color: Colors.orange.withOpacity(0.3),
+                ),
+              ),
+              child: Icon(
+                Icons.search_off,
+                size: 64.sp,
+                color: Colors.orange,
+              ),
+            ),
+            SizedBox(height: 24.h),
+            Text(
+              'No Groups Found',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 24.sp,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            SizedBox(height: 12.h),
+            Text(
+              'Try searching with a different name',
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.7),
+                fontSize: 16.sp,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSearchResults() {
+    return ListView.builder(
+      padding: EdgeInsets.fromLTRB(20.w, 20.h, 20.w, 20.h),
+      itemCount: _searchResults.length,
+      itemBuilder: (context, index) {
+        final group = _searchResults[index];
+        return _buildGroupCard(group, index);
+      },
+    );
+  }
+
+  Widget _buildGroupCard(FriendGroup group, int index) {
+    return TweenAnimationBuilder<double>(
+      duration: Duration(milliseconds: 300 + (index * 100)),
+      tween: Tween(begin: 0.0, end: 1.0),
+      builder: (context, value, child) {
+        return Transform.translate(
+          offset: Offset(0, 20.h * (1 - value)),
+          child: Opacity(
+            opacity: value,
+            child: Container(
+              margin: EdgeInsets.only(bottom: 16.h),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(16.r),
+                gradient: const LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [
+                    Color(0xFF2A2A2A),
+                    Color(0xFF1F1F1F),
+                  ],
+                ),
+                border: Border.all(
+                  color: const Color(0xFFE5A00D).withOpacity(0.2),
+                  width: 1.w,
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.3),
+                    blurRadius: 8.r,
+                    offset: Offset(0, 2.h),
+                  ),
+                ],
+              ),
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => GroupDetailScreen(
+                        group: group,
+                        currentUser: widget.currentUser,
+                        allMovies: widget.allMovies,
+                        onGroupUpdated: () {},
+                      ),
+                    ),
+                  ),
+                  borderRadius: BorderRadius.circular(16.r),
+                  child: Padding(
+                    padding: EdgeInsets.all(16.w),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Container(
+                              width: 56.w,
+                              height: 56.h,
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  colors: [
+                                    const Color(0xFFE5A00D),
+                                    Colors.orange.shade600,
+                                  ],
+                                  begin: Alignment.topLeft,
+                                  end: Alignment.bottomRight,
+                                ),
+                                borderRadius: BorderRadius.circular(14.r),
+                                boxShadow: [
+                                  BoxShadow(
+                                    color: const Color(0xFFE5A00D)
+                                        .withOpacity(0.4),
+                                    blurRadius: 10,
+                                    offset: const Offset(0, 3),
+                                  ),
+                                ],
+                              ),
+                              child: group.imageUrl.isNotEmpty
+                                  ? ClipRRect(
+                                      borderRadius: BorderRadius.circular(14.r),
+                                      child: Image.network(
+                                        group.imageUrl,
+                                        fit: BoxFit.cover,
+                                        errorBuilder: (context, error, stack) {
+                                          return const Icon(Icons.group,
+                                              color: Colors.white, size: 28);
+                                        },
+                                      ),
+                                    )
+                                  : const Icon(Icons.group,
+                                      color: Colors.white, size: 28),
+                            ),
+                            SizedBox(width: 16.w),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    group.name,
+                                    style: TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 16.sp,
+                                      fontWeight: FontWeight.bold,
+                                      letterSpacing: 0.3,
+                                    ),
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  SizedBox(height: 4.h),
+                                  if (group.description.isNotEmpty)
+                                    Text(
+                                      group.description,
+                                      style: TextStyle(
+                                        color:
+                                            Colors.white.withOpacity(0.7),
+                                        fontSize: 12.sp,
+                                      ),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                        if (group.members.isNotEmpty) ...[
+                          SizedBox(height: 12.h),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: SizedBox(
+                                  height: 32.h,
+                                  child: Stack(
+                                    children: [
+                                      ...group.members
+                                          .take(5)
+                                          .toList()
+                                          .asMap()
+                                          .entries
+                                          .map((entry) {
+                                        final idx = entry.key;
+                                        final member = entry.value;
+                                        return Positioned(
+                                          left: idx * 24.0,
+                                          child: Container(
+                                            width: 32.w,
+                                            height: 32.h,
+                                            decoration: BoxDecoration(
+                                              gradient: LinearGradient(
+                                                colors: [
+                                                  Colors.grey[600]!,
+                                                  Colors.grey[800]!,
+                                                ],
+                                                begin: Alignment.topLeft,
+                                                end: Alignment.bottomRight,
+                                              ),
+                                              shape: BoxShape.circle,
+                                              border: Border.all(
+                                                  color: const Color(0xFF1F1F1F),
+                                                  width: 2.w),
+                                            ),
+                                            child: Center(
+                                              child: Text(
+                                                member.name.isNotEmpty
+                                                    ? member.name
+                                                        .substring(0, 1)
+                                                        .toUpperCase()
+                                                    : '?',
+                                                style: TextStyle(
+                                                  fontSize: 11.sp,
+                                                  fontWeight: FontWeight.bold,
+                                                  color: Colors.white,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                        );
+                                      }).toList(),
+                                      if (group.members.length > 5)
+                                        Positioned(
+                                          left: 5 * 24.0,
+                                          child: Container(
+                                            width: 32.w,
+                                            height: 32.h,
+                                            decoration: BoxDecoration(
+                                              color: Colors.black54,
+                                              shape: BoxShape.circle,
+                                              border: Border.all(
+                                                  color: const Color(0xFF1F1F1F),
+                                                  width: 2.w),
+                                            ),
+                                            child: Center(
+                                              child: Text(
+                                                '+${group.members.length - 5}',
+                                                style: TextStyle(
+                                                  fontSize: 9.sp,
+                                                  fontWeight: FontWeight.bold,
+                                                  color: Colors.white,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                              Container(
+                                padding: EdgeInsets.symmetric(
+                                    horizontal: 8.w, vertical: 4.h),
+                                decoration: BoxDecoration(
+                                  color: Colors.white.withOpacity(0.1),
+                                  borderRadius: BorderRadius.circular(8.r),
+                                ),
+                                child: Text(
+                                  '${group.memberCount} members',
+                                  style: TextStyle(
+                                    color: Colors.white54,
+                                    fontSize: 10.sp,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/lib/screens/friends_screen.dart
+++ b/lib/screens/friends_screen.dart
@@ -8,6 +8,7 @@ import 'friend_profile_screen.dart';
 import 'add_friend_screen.dart';
 import 'create_group_screen.dart';
 import 'group_detail_screen.dart';
+import 'find_group_screen.dart';
 import '../services/friendship_service.dart';
 import '../services/group_service.dart';
 import '../utils/debug_loader.dart';
@@ -477,6 +478,100 @@ class _FriendsScreenState extends State<FriendsScreen> with SingleTickerProvider
                             SizedBox(height: 2.h),
                             Text(
                               'Start a movie group with friends',
+                              style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.8),
+                                fontSize: 14.sp,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Icon(
+                        Icons.arrow_forward_ios,
+                        color: Colors.white.withValues(alpha: 0.8),
+                        size: 16.sp,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+
+        // Find Groups Button
+        Container(
+          margin: EdgeInsets.fromLTRB(16.w, 0, 16.w, 16.h),
+          child: GlassmorphicContainer(
+            width: double.infinity,
+            height: 60.h,
+            borderRadius: 16,
+            blur: 15,
+            alignment: Alignment.center,
+            border: 1,
+            linearGradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                const Color(0xFFE5A00D).withValues(alpha: 0.3),
+                Colors.orange.withValues(alpha: 0.25),
+                Colors.orange.shade600.withValues(alpha: 0.2),
+              ],
+            ),
+            borderGradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                const Color(0xFFE5A00D).withValues(alpha: 0.6),
+                Colors.orange.withValues(alpha: 0.4),
+                Colors.white.withValues(alpha: 0.2),
+              ],
+            ),
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => FindGroupScreen(
+                      currentUser: widget.currentUser,
+                      allMovies: widget.allMovies,
+                    ),
+                  ),
+                ),
+                borderRadius: BorderRadius.circular(16.r),
+                child: Container(
+                  padding: EdgeInsets.symmetric(horizontal: 20.w),
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: EdgeInsets.all(12.w),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withValues(alpha: 0.2),
+                          borderRadius: BorderRadius.circular(12.r),
+                        ),
+                        child: Icon(
+                          Icons.search,
+                          color: Colors.white,
+                          size: 24.sp,
+                        ),
+                      ),
+                      SizedBox(width: 16.w),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Find Groups',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 18.sp,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            SizedBox(height: 2.h),
+                            Text(
+                              'Discover public groups',
                               style: TextStyle(
                                 color: Colors.white.withValues(alpha: 0.8),
                                 fontSize: 14.sp,


### PR DESCRIPTION
## Summary
- add `FindGroupScreen` to search for public groups
- allow opening group search from Friends screen

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686013dbb5288330b6810c04f845b6c8