### PR TITLE
Remove lock icons from mode cards - simplify UX flow

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -549,9 +549,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   }
 
   Widget _buildModeSelection() {
-    final hasFriends = widget.profile.friendIds.isNotEmpty;
-    final hasGroups = widget.profile.groupIds.isNotEmpty;
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -574,33 +571,26 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 Icons.person,
                 const Color(0xFFE5A00D),
                 () => widget.onNavigateToSoloMatcher?.call(),
-                isUnlocked: true,
               ),
             ),
             SizedBox(width: 12.w),
             Expanded(
               child: _buildModeCard(
                 'Friend',
-                hasFriends ? 'Match together' : 'Add friends first',
+                'Match together',
                 Icons.people,
                 Colors.purple,
-                hasFriends
-                    ? () => widget.onNavigateToFriendMatcher?.call()
-                    : widget.onNavigateToFriends,
-                isUnlocked: hasFriends,
+                () => widget.onNavigateToFriendMatcher?.call(),
               ),
             ),
             SizedBox(width: 12.w),
             Expanded(
               child: _buildModeCard(
                 'Group',
-                hasGroups ? 'Party mode' : 'Create group first',
+                'Party mode',
                 Icons.groups,
                 Colors.indigo,
-                hasGroups
-                    ? () => widget.onNavigateToGroupMatcher?.call()
-                    : widget.onNavigateToFriends, // Groups tab is in friends screen
-                isUnlocked: hasGroups,
+                () => widget.onNavigateToGroupMatcher?.call(),
               ),
             ),
           ],
@@ -609,20 +599,16 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     );
   }
 
-  Widget _buildModeCard(String title, String subtitle, IconData icon, Color color, VoidCallback? onTap, {bool isUnlocked = true}) {
+  Widget _buildModeCard(String title, String subtitle, IconData icon, Color color, VoidCallback? onTap) {
     return GestureDetector(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.all(16.w),
         decoration: BoxDecoration(
-          color: isUnlocked
-              ? color.withValues(alpha: 0.2)
-              : Colors.grey.withValues(alpha: 0.1),
+          color: color.withValues(alpha: 0.2),
           borderRadius: BorderRadius.circular(16.r),
           border: Border.all(
-            color: isUnlocked
-                ? color.withValues(alpha: 0.4)
-                : Colors.grey.withValues(alpha: 0.3),
+            color: color.withValues(alpha: 0.4),
             width: 1.w,
           ),
           boxShadow: [
@@ -635,40 +621,14 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         ),
         child: Column(
           children: [
-            Stack(
-              alignment: Alignment.center,
-              children: [
-                Icon(
-                  icon,
-                  size: 28.sp,
-                  color: isUnlocked ? color : Colors.grey,
-                ),
-                if (!isUnlocked)
-                  Positioned(
-                    right: -4.w,
-                    top: -4.h,
-                    child: Container(
-                      padding: EdgeInsets.all(3.w),
-                      decoration: BoxDecoration(
-                        color: Colors.grey[700],
-                        shape: BoxShape.circle,
-                      ),
-                      child: Icon(
-                        Icons.lock,
-                        size: 12.sp,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ),
-              ],
-            ),
+            Icon(icon, size: 28.sp, color: color),
             SizedBox(height: 8.h),
             Text(
               title,
               style: TextStyle(
                 fontSize: 14.sp,
                 fontWeight: FontWeight.bold,
-                color: isUnlocked ? Colors.white : Colors.grey,
+                color: Colors.white,
               ),
             ),
             SizedBox(height: 4.h),
@@ -676,11 +636,9 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
               subtitle,
               style: TextStyle(
                 fontSize: 10.sp,
-                color: isUnlocked ? Colors.white70 : Colors.grey[600],
+                color: Colors.white70,
               ),
               textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
             ),
           ],
         ),

--- a/lib/widgets/matcher/session_hub_widget.dart
+++ b/lib/widgets/matcher/session_hub_widget.dart
@@ -324,23 +324,26 @@ class _SessionHubWidgetState extends State<SessionHubWidget> {
       if (!hasFriends) {
         return _buildEmptyHistoryState(
           mode: MatchingMode.friend,
-          title: "Add Friends to Match Together",
-          message: "Friend matching is the heart of Zura! Add friends to start discovering movies you'll both love.",
-          actionText: "Add Friends",
+          title: "You Have No Friends",
+          message: "Add friends to start matching together! Go to the Friends tab (3rd icon) to search and add friends.",
+          actionText: "Got It",
           onAction: () {
-            // Navigate to friends tab
-            Navigator.of(context).popUntil((route) => route.isFirst);
+            ThemedNotifications.showInfo(
+              context,
+              'Tap the Friends icon (3rd from left) to add friends!',
+              icon: "👥",
+            );
           },
-          icon: Icons.person_add,
+          icon: Icons.person_add_outlined,
         );
       } else {
         return _buildEmptyHistoryState(
           mode: MatchingMode.friend,
           title: "No Friend Sessions Yet",
           message: "Invite a friend to start matching! You'll swipe together and see what movies you both like.",
-          actionText: "Invite a Friend",
+          actionText: "Start Session",
           onAction: widget.onShowMoodPicker,
-          icon: Icons.send,
+          icon: Icons.play_arrow,
         );
       }
     }
@@ -400,23 +403,26 @@ class _SessionHubWidgetState extends State<SessionHubWidget> {
       if (!hasGroups) {
         return _buildEmptyHistoryState(
           mode: MatchingMode.group,
-          title: "Create a Group to Get Started",
-          message: "Group matching is perfect for movie nights with friends! Create a group and invite everyone to find the perfect film together.",
-          actionText: "Create Group",
+          title: "You Have No Groups",
+          message: "Create a group to match with multiple friends! Go to the Friends tab (3rd icon) and tap Groups to create one.",
+          actionText: "Got It",
           onAction: () {
-            // Navigate to friends tab where groups can be created
-            Navigator.of(context).popUntil((route) => route.isFirst);
+            ThemedNotifications.showInfo(
+              context,
+              'Tap Friends icon, then tap Groups tab to create a group!',
+              icon: "👥",
+            );
           },
-          icon: Icons.group_add,
+          icon: Icons.group_add_outlined,
         );
       } else {
         return _buildEmptyHistoryState(
           mode: MatchingMode.group,
           title: "No Group Sessions Yet",
           message: "Select a group and start swiping together! Everyone's votes count toward finding the perfect match.",
-          actionText: "Start Group Session",
+          actionText: "Start Session",
           onAction: widget.onShowMoodPicker,
-          icon: Icons.groups,
+          icon: Icons.play_arrow,
         );
       }
     }


### PR DESCRIPTION
CHANGE: Based on user feedback, removed confusing lock icons from Friend/Group mode cards

BEFORE:
- Friend/Group modes showed lock icons when user had no friends/groups
- Clicking locked modes tried to navigate to Friends screen
- Added cognitive load - users had to understand "why is this locked?"

AFTER:
- All mode cards are always clickable (no locks)
- Users can freely explore any mode they want
- Empty states in Matcher screen guide users contextually:
  - "You Have No Friends" with clear instructions to go to Friends tab
  - "You Have No Groups" with clear instructions to create groups
  - "Got It" button shows helpful notification

WHY THIS IS BETTER:
1. Less friction - users can click what they want
2. Context is clearer - they see the empty state exactly where they need it
3. Instructions are specific - "Go to Friends tab (3rd icon)"
4. Natural discovery - users learn by exploring

EMPTY STATES NOW SAY:
- Friend mode (no friends): "You Have No Friends" + directions to Friends tab
- Friend mode (has friends): "No Friend Sessions Yet" + "Start Session" button
- Group mode (no groups): "You Have No Groups" + directions to create group
- Group mode (has groups): "No Group Sessions Yet" + "Start Session" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)