### PR TITLE
Fix session creation flow - provide step-by-step guidance instead of …

### DIFF
--- a/lib/widgets/matcher/session_hub_widget.dart
+++ b/lib/widgets/matcher/session_hub_widget.dart
@@ -340,10 +340,10 @@ class _SessionHubWidgetState extends State<SessionHubWidget> {
         return _buildEmptyHistoryState(
           mode: MatchingMode.friend,
           title: "No Friend Sessions Yet",
-          message: "Invite a friend to start matching! You'll swipe together and see what movies you both like.",
-          actionText: "Start Session",
-          onAction: widget.onShowMoodPicker,
-          icon: Icons.play_arrow,
+          message: "To start matching with a friend:\n\n1. Tap \"Invite Friend\" button above\n2. Select a friend\n3. Choose your mood\n4. Wait for them to accept\n5. Start swiping together!",
+          actionText: null,
+          onAction: null,
+          icon: Icons.swap_horiz,
         );
       }
     }
@@ -419,10 +419,10 @@ class _SessionHubWidgetState extends State<SessionHubWidget> {
         return _buildEmptyHistoryState(
           mode: MatchingMode.group,
           title: "No Group Sessions Yet",
-          message: "Select a group and start swiping together! Everyone's votes count toward finding the perfect match.",
-          actionText: "Start Session",
-          onAction: widget.onShowMoodPicker,
-          icon: Icons.play_arrow,
+          message: "To start matching with a group:\n\n1. Tap \"Select Group\" button above\n2. Choose which group\n3. Pick your mood\n4. Wait for at least 1 person to join\n5. Start swiping! (Others can join anytime)",
+          actionText: null,
+          onAction: null,
+          icon: Icons.groups,
         );
       }
     }


### PR DESCRIPTION
…shortcuts

PROBLEM:
Multiple ways to start sessions created confusion. "Start Session" button in empty states bypassed the proper flow of selecting friend/group first.

CORRECT FLOW:

Friend Mode:
1. Tap "Invite Friend" button
2. Select a specific friend
3. Choose your mood
4. Wait for friend to accept
5. Start swiping together

Group Mode:
1. Tap "Select Group" button
2. Choose which group
3. Pick your mood
4. Wait for at least 1 person to join
5. Start swiping (others can join anytime)

CHANGES:

Friend Mode Empty State (has friends):
BEFORE: "No Friend Sessions Yet" + [Start Session] button → opens mood picker (wrong!) AFTER: Shows 5-step instructions pointing to "Invite Friend" button above

Group Mode Empty State (has groups):
BEFORE: "No Group Sessions Yet" + [Start Session] button → opens mood picker (wrong!) AFTER: Shows 5-step instructions pointing to "Select Group" button above

WHY THIS IS BETTER:
- One clear path to start sessions (no shortcuts)
- Users learn the proper workflow
- Reduces confusion about "where do I select my friend?"
- Instructions reference actual UI elements ("button above")

🤖 Generated with [Claude Code](https://claude.com/claude-code)